### PR TITLE
BLZT-20: add support Properties injection (via @Value) and profile su…

### DIFF
--- a/core/src/main/java/com/bobocode/bring/core/anotation/Profile.java
+++ b/core/src/main/java/com/bobocode/bring/core/anotation/Profile.java
@@ -1,0 +1,16 @@
+package com.bobocode.bring.core.anotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ *  @author Blyzhnytsia Team
+ *  @since 1.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Profile {
+    String value() default "";
+}

--- a/core/src/main/java/com/bobocode/bring/core/anotation/Value.java
+++ b/core/src/main/java/com/bobocode/bring/core/anotation/Value.java
@@ -1,0 +1,18 @@
+package com.bobocode.bring.core.anotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ *
+ *  @author Blyzhnytsia Team
+ *  @since 1.0
+ */
+@Target({ElementType.PARAMETER, ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Value {
+
+    String value();
+}

--- a/core/src/main/java/com/bobocode/bring/core/context/impl/BringApplicationContext.java
+++ b/core/src/main/java/com/bobocode/bring/core/context/impl/BringApplicationContext.java
@@ -2,6 +2,7 @@ package com.bobocode.bring.core.context.impl;
 
 import com.bobocode.bring.core.context.BringBeanFactory;
 import com.bobocode.bring.core.context.scaner.ClassPathScannerFactory;
+import com.bobocode.bring.core.context.type.TypeResolverFactory;
 import com.bobocode.bring.core.domain.BeanDefinition;
 import com.bobocode.bring.core.domain.BeanTypeEnum;
 import com.bobocode.bring.core.postprocessor.BeanPostProcessor;
@@ -107,6 +108,8 @@ public class BringApplicationContext extends AnnotationBringBeanRegistry impleme
     private void invokeBeanFactoryPostProcessors() {
         beanPostProcessorDefinitionFactory.getBeanFactoryPostProcessors()
                 .forEach(processor -> processor.postProcessBeanFactory(this));
+
+        setTypeResolverFactory(new TypeResolverFactory(getProperties()));
     }
 
     private void invokeBeanPostProcessors() {

--- a/core/src/main/java/com/bobocode/bring/core/context/impl/DefaultBringBeanFactory.java
+++ b/core/src/main/java/com/bobocode/bring/core/context/impl/DefaultBringBeanFactory.java
@@ -1,10 +1,13 @@
 package com.bobocode.bring.core.context.impl;
 
 import com.bobocode.bring.core.context.BringBeanFactory;
+import com.bobocode.bring.core.context.type.TypeResolverFactory;
 import com.bobocode.bring.core.domain.BeanDefinition;
 import com.bobocode.bring.core.exception.BeansException;
 import com.bobocode.bring.core.exception.NoSuchBeanException;
 import com.bobocode.bring.core.exception.NoUniqueBeanException;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +25,18 @@ public class DefaultBringBeanFactory implements BringBeanFactory {
     private final Map<String, Object> singletonObjects = new ConcurrentHashMap<>();
     
     private final Map<String, List<Object>> interfaceNameToImplementations = new ConcurrentHashMap<>();
+
+    @Setter
+    @Getter
+    private Map<String, String> properties = new ConcurrentHashMap<>();
+
+    @Setter
+    @Getter
+    private String profileName;
+
+    @Setter
+    @Getter
+    private TypeResolverFactory typeResolverFactory;
 
     @Override
     public <T> T getBean(Class<T> type) throws BeansException {

--- a/core/src/main/java/com/bobocode/bring/core/context/scaner/ClassPathScannerFactory.java
+++ b/core/src/main/java/com/bobocode/bring/core/context/scaner/ClassPathScannerFactory.java
@@ -2,6 +2,7 @@ package com.bobocode.bring.core.context.scaner;
 
 import com.bobocode.bring.core.context.scaner.impl.ComponentClassPathScanner;
 import com.bobocode.bring.core.context.scaner.impl.ConfigurationClassPathScanner;
+import com.bobocode.bring.core.context.scaner.impl.ProfileClassPathScanner;
 import com.bobocode.bring.core.context.scaner.impl.ServiceClassPathScanner;
 import lombok.extern.slf4j.Slf4j;
 import org.reflections.Reflections;
@@ -61,7 +62,8 @@ public class ClassPathScannerFactory {
         this.classPathScanners = Arrays.asList(
                 new ComponentClassPathScanner(reflections),
                 new ServiceClassPathScanner(reflections),
-                new ConfigurationClassPathScanner(reflections)
+                new ConfigurationClassPathScanner(reflections),
+                new ProfileClassPathScanner(reflections)
         );
 
         log.info("Register ClassPathScannerFactory {}", Arrays.toString(classPathScanners.toArray()));

--- a/core/src/main/java/com/bobocode/bring/core/context/scaner/impl/ProfileClassPathScanner.java
+++ b/core/src/main/java/com/bobocode/bring/core/context/scaner/impl/ProfileClassPathScanner.java
@@ -1,0 +1,20 @@
+package com.bobocode.bring.core.context.scaner.impl;
+
+import com.bobocode.bring.core.anotation.Profile;
+import com.bobocode.bring.core.context.scaner.ClassPathScanner;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.reflections.Reflections;
+
+import java.util.Set;
+
+@AllArgsConstructor
+@Slf4j
+public class ProfileClassPathScanner implements ClassPathScanner {
+
+    private final Reflections reflections;
+    @Override
+    public Set<Class<?>> scan() {
+        return reflections.getTypesAnnotatedWith(Profile.class);
+    }
+}

--- a/core/src/main/java/com/bobocode/bring/core/context/type/FieldValueTypeInjector.java
+++ b/core/src/main/java/com/bobocode/bring/core/context/type/FieldValueTypeInjector.java
@@ -1,0 +1,10 @@
+package com.bobocode.bring.core.context.type;
+
+import java.lang.reflect.Field;
+
+public interface FieldValueTypeInjector {
+
+    boolean hasAnnotatedWithValue(Field field);
+
+    Field setValueToField(Field field, Object bean);
+}

--- a/core/src/main/java/com/bobocode/bring/core/context/type/ParameterValueTypeInjector.java
+++ b/core/src/main/java/com/bobocode/bring/core/context/type/ParameterValueTypeInjector.java
@@ -1,0 +1,10 @@
+package com.bobocode.bring.core.context.type;
+
+import java.lang.reflect.Parameter;
+
+public interface ParameterValueTypeInjector {
+
+    boolean hasAnnotatedWithValue(Parameter parameter);
+
+    Object setValueToSetter(Parameter parameter);
+}

--- a/core/src/main/java/com/bobocode/bring/core/context/type/PropertyFieldValueTypeInjector.java
+++ b/core/src/main/java/com/bobocode/bring/core/context/type/PropertyFieldValueTypeInjector.java
@@ -1,0 +1,30 @@
+package com.bobocode.bring.core.context.type;
+
+import com.bobocode.bring.core.anotation.Value;
+import com.bobocode.bring.core.utils.ReflectionUtils;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+@AllArgsConstructor
+@Slf4j
+public class PropertyFieldValueTypeInjector implements FieldValueTypeInjector {
+
+    private final Map<String, String> properties;
+
+    @Override
+    public boolean hasAnnotatedWithValue(Field field) {
+        return field.isAnnotationPresent(Value.class);
+    }
+
+    @Override
+    public Field setValueToField(Field field, Object bean) {
+        Value valueAnnotation = field.getAnnotation(Value.class);
+        String key = valueAnnotation.value();
+        String value = properties.get(key);
+        ReflectionUtils.setField(field, bean, field.getType().cast(value));
+        return field;
+    }
+}

--- a/core/src/main/java/com/bobocode/bring/core/context/type/PropertyParameterValueTypeInjector.java
+++ b/core/src/main/java/com/bobocode/bring/core/context/type/PropertyParameterValueTypeInjector.java
@@ -1,0 +1,31 @@
+package com.bobocode.bring.core.context.type;
+
+import com.bobocode.bring.core.anotation.Value;
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.Parameter;
+import java.util.Map;
+
+@AllArgsConstructor
+@Slf4j
+public class PropertyParameterValueTypeInjector implements ParameterValueTypeInjector {
+
+    private final Map<String, String> properties;
+
+    @Override
+    public boolean hasAnnotatedWithValue(Parameter parameter) {
+        return parameter.isAnnotationPresent(Value.class);
+    }
+
+    @SneakyThrows
+    @Override
+    public Object setValueToSetter(Parameter parameter) {
+        Value valueAnnotation = parameter.getAnnotation(Value.class);
+        Class<?> type = parameter.getType();
+        String key = valueAnnotation.value();
+        String value = properties.get(key);
+        return type.cast(value);
+    }
+}

--- a/core/src/main/java/com/bobocode/bring/core/context/type/TypeResolverFactory.java
+++ b/core/src/main/java/com/bobocode/bring/core/context/type/TypeResolverFactory.java
@@ -1,0 +1,29 @@
+package com.bobocode.bring.core.context.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+@Slf4j
+public class TypeResolverFactory {
+
+    private final List<FieldValueTypeInjector> fieldValueTypeInjectors;
+    private final List<ParameterValueTypeInjector> parameterValueTypeInjectors;
+
+    private final Map<String, String> properties;
+
+    public TypeResolverFactory(Map<String, String> properties) {
+        this.properties = properties;
+        this.fieldValueTypeInjectors = List.of(
+                new PropertyFieldValueTypeInjector(properties)
+        );
+        this.parameterValueTypeInjectors = List.of(
+                new PropertyParameterValueTypeInjector(properties)
+        );
+    }
+}

--- a/core/src/main/java/com/bobocode/bring/core/domain/BeanDefinition.java
+++ b/core/src/main/java/com/bobocode/bring/core/domain/BeanDefinition.java
@@ -24,5 +24,9 @@ public class BeanDefinition {
     public boolean isConfiguration() {
         return this.beanType == BeanTypeEnum.CONFIGURATION;
     }
+
+    public boolean isProfile() {
+        return this.beanType == BeanTypeEnum.PROFILE;
+    }
     
 }

--- a/core/src/main/java/com/bobocode/bring/core/domain/BeanTypeEnum.java
+++ b/core/src/main/java/com/bobocode/bring/core/domain/BeanTypeEnum.java
@@ -1,9 +1,6 @@
 package com.bobocode.bring.core.domain;
 
-import com.bobocode.bring.core.anotation.Bean;
-import com.bobocode.bring.core.anotation.Component;
-import com.bobocode.bring.core.anotation.Configuration;
-import com.bobocode.bring.core.anotation.Service;
+import com.bobocode.bring.core.anotation.*;
 import com.bobocode.bring.core.exception.BeanAnnotationMissingException;
 import com.bobocode.bring.core.utils.Pair;
 import lombok.Getter;
@@ -24,7 +21,9 @@ public enum BeanTypeEnum {
 
     SERVICE(3, Service.class),
 
-    COMPONENT(3, Component.class);
+    COMPONENT(3, Component.class),
+
+    PROFILE(3, Profile .class);
 
     private final int order;
     

--- a/core/src/main/java/com/bobocode/bring/core/env/BringSourceLoader.java
+++ b/core/src/main/java/com/bobocode/bring/core/env/BringSourceLoader.java
@@ -1,0 +1,10 @@
+package com.bobocode.bring.core.env;
+
+import java.util.Map;
+
+public interface BringSourceLoader {
+
+    String getFileExtensions();
+
+    Map<String, String> load(String name);
+}

--- a/core/src/main/java/com/bobocode/bring/core/env/BringSourceScanner.java
+++ b/core/src/main/java/com/bobocode/bring/core/env/BringSourceScanner.java
@@ -1,0 +1,9 @@
+package com.bobocode.bring.core.env;
+
+import java.io.File;
+import java.util.List;
+
+public interface BringSourceScanner {
+
+    List<File> scan(String type);
+}

--- a/core/src/main/java/com/bobocode/bring/core/env/impl/BringPropertiesSourceScanner.java
+++ b/core/src/main/java/com/bobocode/bring/core/env/impl/BringPropertiesSourceScanner.java
@@ -1,0 +1,47 @@
+package com.bobocode.bring.core.env.impl;
+
+import com.bobocode.bring.core.env.BringSourceScanner;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+
+@Slf4j
+public class BringPropertiesSourceScanner implements BringSourceScanner {
+    private static final String APPLICATION = "application";
+
+    @Override
+    public List<File> scan(String type) {
+        return loadAllProperties(type);
+    }
+
+    @SneakyThrows
+    private List<File> loadAllProperties(String type) {
+        List<File> refFiles = new ArrayList<>();
+        String applicationProperties = APPLICATION + type;
+
+        URL resource = getClass().getClassLoader().getResource(applicationProperties);
+        if (Objects.isNull(resource)) {
+            log.warn("No resources directory found in classpath");
+            return refFiles;
+        }
+
+        Path folderPath = Paths.get(resource.toURI()).resolve("..").normalize();
+
+        File[] files = folderPath.toFile().listFiles();
+
+        if (Objects.nonNull(files)) {
+            refFiles = Arrays.stream(files)
+                    .filter(file -> file.isFile() && file.getName().endsWith(type))
+                    .sorted(Comparator.comparing(File::getName).reversed())
+                    .toList();
+        }
+
+        return refFiles;
+    }
+}

--- a/core/src/main/java/com/bobocode/bring/core/env/impl/BringPropertySourceLoader.java
+++ b/core/src/main/java/com/bobocode/bring/core/env/impl/BringPropertySourceLoader.java
@@ -1,0 +1,58 @@
+package com.bobocode.bring.core.env.impl;
+
+import com.bobocode.bring.core.env.BringSourceLoader;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+import static java.util.stream.Collectors.toMap;
+
+@Slf4j
+public class BringPropertySourceLoader implements BringSourceLoader {
+
+    public static final String APPLICATION_PROPERTIES = "application.properties";
+
+    @Override
+    public String getFileExtensions() {
+        return "properties";
+    }
+
+    @Override
+    public Map<String, String> load(String name) {
+        Map<String, String> defaultProperties = loadProperties(APPLICATION_PROPERTIES);
+        Map<String, String> overrideProperties = loadProperties(name);
+        defaultProperties.putAll(overrideProperties);
+        return defaultProperties;
+    }
+
+
+    private static Map<String, String> loadProperties(String fileName) {
+        String defaultFileName  = (fileName == null) ? APPLICATION_PROPERTIES : fileName;
+        Map<String, String> propertiesMap = new HashMap<>();
+
+        try (InputStream source = BringPropertySourceLoader.class.getClassLoader().getResourceAsStream(defaultFileName)) {
+            if (Objects.isNull(source)) {
+                log.warn("Cannot find file {}. Will use default one {}", fileName, APPLICATION_PROPERTIES);
+                return propertiesMap;
+            }
+
+            Properties properties = new Properties();
+            properties.load(source);
+
+            propertiesMap = properties.stringPropertyNames()
+                    .stream()
+                    .collect(toMap(key -> key, properties::getProperty, (a, b) -> b));
+
+        } catch (IOException exe) {
+            log.error("Error loading properties from file {}: {}. Will use default one {}", defaultFileName,
+                    exe.getMessage(), APPLICATION_PROPERTIES);
+        }
+
+        return propertiesMap;
+    }
+}

--- a/core/src/main/java/com/bobocode/bring/core/env/impl/ProfileSourceResolve.java
+++ b/core/src/main/java/com/bobocode/bring/core/env/impl/ProfileSourceResolve.java
@@ -1,0 +1,33 @@
+package com.bobocode.bring.core.env.impl;
+
+import com.bobocode.bring.core.env.BringSourceLoader;
+import com.bobocode.bring.core.env.BringSourceScanner;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+public class ProfileSourceResolve {
+
+    private final BringSourceLoader bringSourceLoader;
+    private final BringSourceScanner bringSourceScanner;
+
+    public ProfileSourceResolve() {
+        this.bringSourceLoader = new BringPropertySourceLoader();
+        this.bringSourceScanner = new BringPropertiesSourceScanner();
+    }
+
+    public Map<String, String> resolve(String profileName, String type) {
+        Map<String, String> properties = new HashMap<>();
+        bringSourceScanner.scan(type).forEach(file -> {
+            String name = file.getName();
+            if (name.equals(BringPropertySourceLoader.APPLICATION_PROPERTIES) || (Objects.nonNull(profileName) && name.contains(profileName))) {
+                properties.putAll(bringSourceLoader.load(file.getName()));
+            }
+        });
+
+        return properties;
+    }
+}

--- a/core/src/main/java/com/bobocode/bring/core/postprocessor/BeanPostProcessorDefinitionFactory.java
+++ b/core/src/main/java/com/bobocode/bring/core/postprocessor/BeanPostProcessorDefinitionFactory.java
@@ -1,6 +1,7 @@
 package com.bobocode.bring.core.postprocessor;
 
 import com.bobocode.bring.core.postprocessor.impl.ConfigurationClassPostProcessor;
+import com.bobocode.bring.core.postprocessor.impl.ValuePropertiesPostProcessor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,6 +50,7 @@ public class BeanPostProcessorDefinitionFactory {
      */
     public BeanPostProcessorDefinitionFactory() {
         beanFactoryPostProcessors = List.of(
+                new ValuePropertiesPostProcessor(),
                 new ConfigurationClassPostProcessor()
         );
 

--- a/core/src/main/java/com/bobocode/bring/core/postprocessor/impl/ValuePropertiesPostProcessor.java
+++ b/core/src/main/java/com/bobocode/bring/core/postprocessor/impl/ValuePropertiesPostProcessor.java
@@ -1,0 +1,41 @@
+package com.bobocode.bring.core.postprocessor.impl;
+
+import com.bobocode.bring.core.anotation.Profile;
+import com.bobocode.bring.core.context.impl.DefaultBringBeanFactory;
+import com.bobocode.bring.core.domain.BeanDefinition;
+import com.bobocode.bring.core.env.impl.ProfileSourceResolve;
+import com.bobocode.bring.core.postprocessor.BeanFactoryPostProcessor;
+
+import java.util.Map;
+
+public class ValuePropertiesPostProcessor implements BeanFactoryPostProcessor {
+
+    public static final String PROPERTIES = ".properties";
+    private final ProfileSourceResolve profileSourceResolve = new ProfileSourceResolve();
+    
+    @Override
+    public void postProcessBeanFactory(DefaultBringBeanFactory defaultBeanFactory) {
+        String profileName = null;
+        Map<String, String> properties = defaultBeanFactory.getProperties();
+
+        if (!properties.isEmpty()) {
+            return;
+        }
+
+        for (String beanName : defaultBeanFactory.getAllBeanDefinitionNames()) {
+            BeanDefinition beanDefinition = defaultBeanFactory.getBeanDefinitionByName(beanName);
+
+            if (beanDefinition.isProfile()) {
+                Class<?> beanClass = beanDefinition.getBeanClass();
+                if (beanClass.isAnnotationPresent(Profile.class)) {
+                    profileName = beanClass.getAnnotation(Profile.class).value();
+                }
+            }
+        }
+
+        properties = profileSourceResolve.resolve(profileName, PROPERTIES);
+        defaultBeanFactory.setProperties(properties);
+        defaultBeanFactory.setProfileName(profileName);
+    }
+
+}

--- a/core/src/main/resources/META-INF/bring-configuration-metadata.json
+++ b/core/src/main/resources/META-INF/bring-configuration-metadata.json
@@ -1,0 +1,14 @@
+{
+  "properties": [
+    {
+      "name": "bring.banner.location",
+      "type": "java.lang.String",
+      "description": "The file path or URL for the main banner location in the application."
+    },
+    {
+      "name": "bring.main.banner-mode",
+      "type": "java.lang.String",
+      "description": "Specifies whether the main banner is turned ON or OFF in the application. Use 'ON' to display the banner and 'OFF' to hide it."
+    }
+  ]
+}

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+bring.main.banner-mode=on

--- a/core/src/test/java/com/bobocode/bring/core/context/impl/BringApplicationContextHappyCasesTest.java
+++ b/core/src/test/java/com/bobocode/bring/core/context/impl/BringApplicationContextHappyCasesTest.java
@@ -5,9 +5,12 @@ import com.bobocode.bring.testdata.di.positive.configuration.client.RestClient;
 import com.bobocode.bring.testdata.di.positive.configuration.configuration.TestConfiguration;
 import com.bobocode.bring.testdata.di.positive.configuration.service.BringService;
 import com.bobocode.bring.testdata.di.positive.constructor.BringBeansService;
+import com.bobocode.bring.testdata.di.positive.constructorproperties.ProfileBeanConstructor;
 import com.bobocode.bring.testdata.di.positive.contract.Barista;
+import com.bobocode.bring.testdata.di.positive.fieldproperties.ProfileBean;
 import com.bobocode.bring.testdata.di.positive.setter.A;
 import com.bobocode.bring.testdata.di.positive.setter.B;
+import com.bobocode.bring.testdata.di.positive.setterproperties.ProfileBeanSetter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -146,6 +149,64 @@ class BringApplicationContextHappyCasesTest {
 
         // then
         assertThat(bringBeansService).isNotNull();
+    }
+
+
+    @DisplayName("Should found profile bean and read application properties and do field injection")
+    @Test
+    void shouldFoundProfileBeanAndReadApplicationPropertiesAndSetValueToFieldInjection() {
+        //when
+        var bringApplicationContext = BringApplication.run(TEST_DATA_PACKAGE + ".fieldproperties");
+        ProfileBean profileBean = bringApplicationContext.getBean(ProfileBean.class);
+
+        //then
+        assertThat(bringApplicationContext.getProfileName()).isEqualTo("dev");
+        assertThat(bringApplicationContext.getProperties()).isNotNull()
+                        .hasSize(1)
+                        .containsEntry("bring.main.banner-mode", "on");
+
+        assertThat(profileBean).isNotNull();
+        assertThat(profileBean.getBannerMode())
+                .isNotNull()
+                .isEqualTo("on");
+    }
+
+    @DisplayName("Should found profile bean and read application properties and do setter injection")
+    @Test
+    void shouldFoundProfileBeanAndReadApplicationPropertiesAndSetValueToSetterInjection() {
+        //when
+        var bringApplicationContext = BringApplication.run(TEST_DATA_PACKAGE + ".setterproperties");
+        ProfileBeanSetter profileBeanSetter = bringApplicationContext.getBean(ProfileBeanSetter.class);
+
+        //then
+        assertThat(bringApplicationContext.getProfileName()).isEqualTo("dev");
+        assertThat(bringApplicationContext.getProperties()).isNotNull()
+                .hasSize(1)
+                .containsEntry("bring.main.banner-mode", "on");
+
+        assertThat(profileBeanSetter).isNotNull();
+        assertThat(profileBeanSetter.getBannerMode())
+                .isNotNull()
+                .isEqualTo("on");
+    }
+
+    @DisplayName("Should found profile bean and read application properties and do constructor injection")
+    @Test
+    void shouldFoundProfileBeanAndReadApplicationPropertiesAndSetValueToConstructorInjection() {
+        //when
+        var bringApplicationContext = BringApplication.run(TEST_DATA_PACKAGE + ".constructorproperties");
+        ProfileBeanConstructor profileBeanConstructor = bringApplicationContext.getBean(ProfileBeanConstructor.class);
+
+        //then
+        assertThat(bringApplicationContext.getProfileName()).isEqualTo("dev");
+        assertThat(bringApplicationContext.getProperties()).isNotNull()
+                .hasSize(1)
+                .containsEntry("bring.main.banner-mode", "on");
+
+        assertThat(profileBeanConstructor).isNotNull();
+        assertThat(profileBeanConstructor.getBannerMode())
+                .isNotNull()
+                .isEqualTo("on");
     }
 
 }

--- a/core/src/test/java/com/bobocode/bring/core/context/impl/BringApplicationContextHappyCasesTest.java
+++ b/core/src/test/java/com/bobocode/bring/core/context/impl/BringApplicationContextHappyCasesTest.java
@@ -5,9 +5,13 @@ import com.bobocode.bring.testdata.di.positive.configuration.client.RestClient;
 import com.bobocode.bring.testdata.di.positive.configuration.configuration.TestConfiguration;
 import com.bobocode.bring.testdata.di.positive.configuration.service.BringService;
 import com.bobocode.bring.testdata.di.positive.constructor.BringBeansService;
+import com.bobocode.bring.testdata.di.positive.constructorproperties.ProfileBeanConstructor;
 import com.bobocode.bring.testdata.di.positive.contract.Barista;
+import com.bobocode.bring.testdata.di.positive.fieldproperties.ProfileBean;
+import com.bobocode.bring.testdata.di.positive.fullinjection.GetInfoFromExternalServicesUseCase;
 import com.bobocode.bring.testdata.di.positive.setter.A;
 import com.bobocode.bring.testdata.di.positive.setter.B;
+import com.bobocode.bring.testdata.di.positive.setterproperties.ProfileBeanSetter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/com/bobocode/bring/core/env/impl/BringPropertiesSourceScannerTest.java
+++ b/core/src/test/java/com/bobocode/bring/core/env/impl/BringPropertiesSourceScannerTest.java
@@ -1,0 +1,41 @@
+package com.bobocode.bring.core.env.impl;
+
+import com.bobocode.bring.core.env.BringSourceScanner;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BringPropertiesSourceScannerTest {
+
+    @DisplayName("Should find two properties files")
+    @Test
+    void shouldFoundTwoPropertiesFiles() {
+        //given
+        BringSourceScanner bringSourceScanner = new BringPropertiesSourceScanner();
+
+        //when
+        List<File> files = bringSourceScanner.scan(".properties");
+
+        //then
+        assertThat(files).isNotNull()
+                .hasSize(3);
+    }
+
+    @DisplayName("Should find zero yml files")
+    @Test
+    void shouldFoundZeroYmlFiles() {
+        //given
+        BringSourceScanner bringSourceScanner = new BringPropertiesSourceScanner();
+
+        //when
+        List<File> files = bringSourceScanner.scan(".yml");
+
+        //then
+        assertThat(files).isNotNull()
+                .hasSize(0);
+    }
+}

--- a/core/src/test/java/com/bobocode/bring/core/env/impl/BringPropertySourceLoaderTest.java
+++ b/core/src/test/java/com/bobocode/bring/core/env/impl/BringPropertySourceLoaderTest.java
@@ -1,0 +1,59 @@
+package com.bobocode.bring.core.env.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BringPropertySourceLoaderTest {
+
+    @DisplayName("Should load application properties")
+    @Test
+    void shouldLoadApplicationProperties() {
+        //given
+        var bringPropertySourceLoader = new BringPropertySourceLoader();
+        String batterMode = "off";
+
+        //when
+        Map<String, String> properties = bringPropertySourceLoader.load("application-test.properties");
+
+        //then
+        assertThat(properties).isNotNull()
+                        .hasSize(1)
+                        .containsEntry("bring.main.banner-mode", batterMode);
+    }
+
+    @DisplayName("Should return empty map when properties file not found")
+    @Test
+    void shouldReturnEmptyMapWhenPropertiesFileNotExistWillUseDefaultOne() {
+        //given
+        var bringPropertySourceLoader = new BringPropertySourceLoader();
+        String batterMode = "on";
+
+        //when
+        Map<String, String> properties = bringPropertySourceLoader.load("application-notFound.properties");
+
+        //then
+        assertThat(properties).isNotNull()
+                .hasSize(1)
+                .containsEntry("bring.main.banner-mode", batterMode);
+    }
+
+    @DisplayName("Should return empty map when properties has wrong type")
+    @Test
+    void shouldReturnDefaultApplicationWhenWePutWrongType() {
+        //given
+        var bringPropertySourceLoader = new BringPropertySourceLoader();
+        String batterMode = "on";
+
+        //when
+        Map<String, String> properties = bringPropertySourceLoader.load("application.qqq");
+
+        //then
+        assertThat(properties).isNotNull()
+                .hasSize(1)
+                .containsEntry("bring.main.banner-mode", batterMode);
+    }
+}

--- a/core/src/test/java/com/bobocode/bring/core/env/impl/ProfileSourceResolveTest.java
+++ b/core/src/test/java/com/bobocode/bring/core/env/impl/ProfileSourceResolveTest.java
@@ -1,0 +1,55 @@
+package com.bobocode.bring.core.env.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProfileSourceResolveTest {
+
+    private ProfileSourceResolve testInstance;
+
+    @BeforeEach
+    void setUp() {
+        testInstance = new ProfileSourceResolve();
+    }
+
+    @DisplayName("Should resolve application properties with profile")
+    @Test
+    void shouldResolveApplicationPropertiesWithProfile() {
+        //when
+        Map<String, String> properties = testInstance.resolve("test", ".properties");
+
+        //then
+        assertThat(properties).isNotNull()
+                .hasSize(1)
+                .containsEntry("bring.main.banner-mode", "off");
+    }
+
+    @DisplayName("Should resolve application properties with profile that not exist")
+    @Test
+    void shouldResolveApplicationPropertiesWithProfileThatNotExist() {
+        //when
+        Map<String, String> properties = testInstance.resolve("dev", ".properties");
+
+        //then
+        assertThat(properties).isNotNull()
+                .hasSize(1)
+                .containsEntry("bring.main.banner-mode", "on");
+    }
+
+    @DisplayName("Should resolve default application properties if profile not defined")
+    @Test
+    void shouldResolveDefaultApplicationPropertiesIfProfileNotDefined() {
+        //when
+        Map<String, String> properties = testInstance.resolve(null, ".properties");
+
+        //then
+        assertThat(properties).isNotNull()
+                .hasSize(1)
+                .containsEntry("bring.main.banner-mode", "on");
+    }
+}

--- a/core/src/test/java/com/bobocode/bring/testdata/di/positive/constructorproperties/ProfileBeanConstructor.java
+++ b/core/src/test/java/com/bobocode/bring/testdata/di/positive/constructorproperties/ProfileBeanConstructor.java
@@ -1,0 +1,22 @@
+package com.bobocode.bring.testdata.di.positive.constructorproperties;
+
+import com.bobocode.bring.core.anotation.Autowired;
+import com.bobocode.bring.core.anotation.Component;
+import com.bobocode.bring.core.anotation.Profile;
+import com.bobocode.bring.core.anotation.Value;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Profile("dev")
+@Component
+public class ProfileBeanConstructor {
+
+    private final String bannerMode;
+
+    @Autowired
+    public ProfileBeanConstructor(@Value("bring.main.banner-mode") String bannerMode) {
+        this.bannerMode = bannerMode;
+    }
+}

--- a/core/src/test/java/com/bobocode/bring/testdata/di/positive/fieldproperties/ProfileBean.java
+++ b/core/src/test/java/com/bobocode/bring/testdata/di/positive/fieldproperties/ProfileBean.java
@@ -1,0 +1,17 @@
+package com.bobocode.bring.testdata.di.positive.fieldproperties;
+
+import com.bobocode.bring.core.anotation.Component;
+import com.bobocode.bring.core.anotation.Profile;
+import com.bobocode.bring.core.anotation.Value;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Profile("dev")
+@Component
+public class ProfileBean {
+
+    @Value("bring.main.banner-mode")
+    private String bannerMode;
+}

--- a/core/src/test/java/com/bobocode/bring/testdata/di/positive/setterproperties/ProfileBeanSetter.java
+++ b/core/src/test/java/com/bobocode/bring/testdata/di/positive/setterproperties/ProfileBeanSetter.java
@@ -1,0 +1,22 @@
+package com.bobocode.bring.testdata.di.positive.setterproperties;
+
+import com.bobocode.bring.core.anotation.Autowired;
+import com.bobocode.bring.core.anotation.Component;
+import com.bobocode.bring.core.anotation.Profile;
+import com.bobocode.bring.core.anotation.Value;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Profile("dev")
+@Component
+public class ProfileBeanSetter {
+
+    private String bannerMode;
+
+    @Autowired
+    public void setBannerMode(@Value("bring.main.banner-mode") String bannerMode) {
+        this.bannerMode = bannerMode;
+    }
+}

--- a/core/src/test/resources/application-test.properties
+++ b/core/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+bring.main.banner-mode=off

--- a/core/src/test/resources/application-uat.properties
+++ b/core/src/test/resources/application-uat.properties
@@ -1,0 +1,2 @@
+bring.application.name=UAT
+bring.application.version=1.0

--- a/core/src/test/resources/application.properties
+++ b/core/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+bring.main.banner-mode=on


### PR DESCRIPTION
- Value injection via field, set, constructor
- application.properties - default one, can be overridden when you set profile, for instance, qa and you have application-qa.properties. That the value that overridden will be more priority.